### PR TITLE
Expand documentation with curated timbres

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -18,7 +18,9 @@
             "pages": [
               "index",
               "quickstart",
-              "development"
+              "development",
+              "raspberry-workstation",
+              "timbres-hits"
             ]
           },
           {

--- a/raspberry-workstation.mdx
+++ b/raspberry-workstation.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Firmware para Workstation em Raspberry Pi'
+---
+
+Este guia apresenta um esqueleto de firmware para transformar seu Raspberry Pi em um teclado workstation. A solução é inspirada em workstations modernas e pode ser expandida conforme a necessidade.
+
+## Visão Geral
+
+O diretório `raspi-workstation` contém:
+
+- `main.py` – ponto de entrada que inicia a interface PyQt5 com tema escuro.
+- `engines/` – motores sonoros (sintetizador, orgão, piano, modelos
+  analógicos/digitais e instrumentos acústicos).
+- `ui/` – componentes de interface, como `MainWindow`.
+
+Execute o projeto após instalar `PyQt5` e `qdarkstyle` com:
+
+```bash
+pip install PyQt5 qdarkstyle
+python main.py
+```
+
+A janela principal exibe abas para diversos motores sonoros (sintetizador,
+sampler, orgão, piano, analógico, FM, D‑50, XP‑80, QuadraSynth, Korg M, DX7,
+orquestral, coral, sanfona, metais, madeiras) além de páginas extras de
+efeitos, ADSR, performance, global, master e arpeggiador.
+
+Essa é apenas uma base inicial. Todos os motores utilizam implementações
+simplificadas; substitua os stubs por algoritmos de síntese adequados para cada
+instrumento.

--- a/raspi-workstation/README.md
+++ b/raspi-workstation/README.md
@@ -1,0 +1,35 @@
+# Firmware para Workstation em Raspberry Pi
+
+Este projeto fornece uma estrutura inicial para criar uma firmware de workstation musical em um Raspberry Pi. O objetivo é oferecer motores sonoros desenvolvidos do zero e uma interface visual em tema escuro com animações. Cada motor sonoro possui sua própria página, além de seções para efeitos, ADSR, performance, global, master e arpeggiador.
+
+## Estrutura Básica
+
+- `main.py`: ponto de entrada da aplicação e inicialização da interface.
+- `engines/`: diretório contendo os motores sonoros (sintetizador, sampler,
+  orgão, piano, analógico, FM, D-50, XP-80, QuadraSynth, Korg M, DX7, orquestral,
+  coral, sanfona, metais e madeiras).
+- `ui/`: componentes de interface criados com PyQt5.
+
+## Pré-Requisitos
+
+- Python 3.9 ou superior instalado no Raspberry Pi.
+- Dependências de interface: `PyQt5` e `QDarkStyle` para tema escuro.
+
+Instalação das dependências (exemplo):
+```bash
+pip install PyQt5 qdarkstyle
+```
+
+## Executando
+
+No terminal do Raspberry Pi, execute:
+```bash
+python main.py
+```
+
+Isso abrirá a janela principal com abas para cada motor sonoro e páginas adicionais (efeitos, ADSR, etc.).
+
+Este repositório contém apenas um esqueleto inicial. Todos os motores listados
+acima ainda utilizam implementações simplificadas. Personalize cada engine com
+algoritmos de síntese (por exemplo, síntese subtrativa, FM ou amostragem) para
+atingir a qualidade desejada.

--- a/raspi-workstation/engines/__init__.py
+++ b/raspi-workstation/engines/__init__.py
@@ -1,0 +1,35 @@
+from .base import BaseEngine
+from .synth_engine import SynthEngine
+from .organ_engine import OrganEngine
+from .piano_engine import PianoEngine
+from .analog_engine import AnalogEngine
+from .fm_engine import FmEngine
+from .d50_engine import D50Engine
+from .xp80_engine import Xp80Engine
+from .quadrasynth_engine import QuadraSynthEngine
+from .korg_m_engine import KorgMEngine
+from .dx7_engine import Dx7Engine
+from .orchestral_engine import OrchestralEngine
+from .choir_engine import ChoirEngine
+from .accordion_engine import AccordionEngine
+from .brass_engine import BrassEngine
+from .woodwind_engine import WoodwindEngine
+
+__all__ = [
+    "BaseEngine",
+    "SynthEngine",
+    "OrganEngine",
+    "PianoEngine",
+    "AnalogEngine",
+    "FmEngine",
+    "D50Engine",
+    "Xp80Engine",
+    "QuadraSynthEngine",
+    "KorgMEngine",
+    "Dx7Engine",
+    "OrchestralEngine",
+    "ChoirEngine",
+    "AccordionEngine",
+    "BrassEngine",
+    "WoodwindEngine",
+]

--- a/raspi-workstation/engines/accordion_engine.py
+++ b/raspi-workstation/engines/accordion_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine for accordion sounds."""
+
+from .base import BaseEngine
+
+
+class AccordionEngine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[Accordion] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[Accordion] Note off {note}")

--- a/raspi-workstation/engines/analog_engine.py
+++ b/raspi-workstation/engines/analog_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine for analog synth sounds."""
+
+from .base import BaseEngine
+
+
+class AnalogEngine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[Analog] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[Analog] Note off {note}")

--- a/raspi-workstation/engines/base.py
+++ b/raspi-workstation/engines/base.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseEngine(ABC):
+    """Base class for all sound engines."""
+
+    @abstractmethod
+    def note_on(self, note: int, velocity: float) -> Any:
+        """Start playing a note."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def note_off(self, note: int) -> Any:
+        """Stop playing a note."""
+        raise NotImplementedError

--- a/raspi-workstation/engines/brass_engine.py
+++ b/raspi-workstation/engines/brass_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine for brass instrument sounds."""
+
+from .base import BaseEngine
+
+
+class BrassEngine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[Brass] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[Brass] Note off {note}")

--- a/raspi-workstation/engines/choir_engine.py
+++ b/raspi-workstation/engines/choir_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine for choir sounds."""
+
+from .base import BaseEngine
+
+
+class ChoirEngine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[Choir] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[Choir] Note off {note}")

--- a/raspi-workstation/engines/d50_engine.py
+++ b/raspi-workstation/engines/d50_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine inspired by the Roland D-50."""
+
+from .base import BaseEngine
+
+
+class D50Engine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[D-50] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[D-50] Note off {note}")

--- a/raspi-workstation/engines/dx7_engine.py
+++ b/raspi-workstation/engines/dx7_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine inspired by the Yamaha DX7."""
+
+from .base import BaseEngine
+
+
+class Dx7Engine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[DX7] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[DX7] Note off {note}")

--- a/raspi-workstation/engines/fm_engine.py
+++ b/raspi-workstation/engines/fm_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine for FM synthesis sounds."""
+
+from .base import BaseEngine
+
+
+class FmEngine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[FM] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[FM] Note off {note}")

--- a/raspi-workstation/engines/korg_m_engine.py
+++ b/raspi-workstation/engines/korg_m_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine inspired by Korg M50/M1 series."""
+
+from .base import BaseEngine
+
+
+class KorgMEngine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[Korg M] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[Korg M] Note off {note}")

--- a/raspi-workstation/engines/orchestral_engine.py
+++ b/raspi-workstation/engines/orchestral_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine for orchestral sounds."""
+
+from .base import BaseEngine
+
+
+class OrchestralEngine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[Orchestral] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[Orchestral] Note off {note}")

--- a/raspi-workstation/engines/organ_engine.py
+++ b/raspi-workstation/engines/organ_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine for organ sounds."""
+
+from .base import BaseEngine
+
+
+class OrganEngine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[Organ] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[Organ] Note off {note}")

--- a/raspi-workstation/engines/piano_engine.py
+++ b/raspi-workstation/engines/piano_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine for piano sounds."""
+
+from .base import BaseEngine
+
+
+class PianoEngine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[Piano] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[Piano] Note off {note}")

--- a/raspi-workstation/engines/quadrasynth_engine.py
+++ b/raspi-workstation/engines/quadrasynth_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine inspired by the Alesis QuadraSynth."""
+
+from .base import BaseEngine
+
+
+class QuadraSynthEngine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[QuadraSynth] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[QuadraSynth] Note off {note}")

--- a/raspi-workstation/engines/synth_engine.py
+++ b/raspi-workstation/engines/synth_engine.py
@@ -1,0 +1,25 @@
+"""Exemplo de motor sonoro para síntese sonora."""
+
+from typing import Any
+
+
+class SynthEngine:
+    """Motor de síntese simplificado."""
+
+    def __init__(self) -> None:
+        self.parameters = {
+            "oscillator": "sine",
+            "filter": {
+                "cutoff": 1000,
+                "resonance": 0.5,
+            },
+        }
+
+    def note_on(self, note: int, velocity: float) -> Any:
+        """Inicia a reprodução de uma nota (simulado)."""
+        # TODO: implementar síntese real
+        print(f"Nota ligada: {note} vel={velocity}")
+
+    def note_off(self, note: int) -> Any:
+        """Encerra a nota (simulado)."""
+        print(f"Nota desligada: {note}")

--- a/raspi-workstation/engines/woodwind_engine.py
+++ b/raspi-workstation/engines/woodwind_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine for woodwind instrument sounds."""
+
+from .base import BaseEngine
+
+
+class WoodwindEngine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[Woodwind] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[Woodwind] Note off {note}")

--- a/raspi-workstation/engines/xp80_engine.py
+++ b/raspi-workstation/engines/xp80_engine.py
@@ -1,0 +1,11 @@
+"""Stub engine inspired by the Roland XP-80."""
+
+from .base import BaseEngine
+
+
+class Xp80Engine(BaseEngine):
+    def note_on(self, note: int, velocity: float) -> None:
+        print(f"[XP-80] Note on {note} vel={velocity}")
+
+    def note_off(self, note: int) -> None:
+        print(f"[XP-80] Note off {note}")

--- a/raspi-workstation/main.py
+++ b/raspi-workstation/main.py
@@ -1,0 +1,19 @@
+"""Aplicativo principal para a firmware de workstation em Raspberry Pi."""
+
+import sys
+from PyQt5 import QtWidgets
+import qdarkstyle
+
+from ui.main_window import MainWindow
+
+
+def main() -> None:
+    app = QtWidgets.QApplication(sys.argv)
+    app.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/raspi-workstation/ui/main_window.py
+++ b/raspi-workstation/ui/main_window.py
@@ -1,0 +1,53 @@
+"""Janela principal com abas para cada motor sonoro e páginas adicionais."""
+
+from PyQt5 import QtWidgets
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Raspberry Workstation")
+        self.resize(1024, 768)
+
+        self.tabs = QtWidgets.QTabWidget()
+        self.setCentralWidget(self.tabs)
+
+        # Abas de motores sonoros
+        self.add_engine_tab("Sintetizador")
+        self.add_engine_tab("Sampler")
+        self.add_engine_tab("Orgão")
+        self.add_engine_tab("Piano")
+        self.add_engine_tab("Analógico")
+        self.add_engine_tab("FM")
+        self.add_engine_tab("D-50")
+        self.add_engine_tab("XP-80")
+        self.add_engine_tab("QuadraSynth")
+        self.add_engine_tab("Korg M")
+        self.add_engine_tab("DX7")
+        self.add_engine_tab("Orquestral")
+        self.add_engine_tab("Coral")
+        self.add_engine_tab("Sanfona")
+        self.add_engine_tab("Metais")
+        self.add_engine_tab("Madeiras")
+
+        # Demais páginas de configurações
+        self.add_page("Efeitos")
+        self.add_page("ADSR")
+        self.add_page("Performance")
+        self.add_page("Global")
+        self.add_page("Master")
+        self.add_page("Arpeggiador")
+
+    def add_engine_tab(self, name: str) -> None:
+        widget = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(widget)
+        label = QtWidgets.QLabel(f"Página do motor {name}")
+        layout.addWidget(label)
+        self.tabs.addTab(widget, name)
+
+    def add_page(self, name: str) -> None:
+        widget = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(widget)
+        label = QtWidgets.QLabel(f"Página de {name}")
+        layout.addWidget(label)
+        self.tabs.addTab(widget, name)

--- a/timbres-hits.mdx
+++ b/timbres-hits.mdx
@@ -1,0 +1,22 @@
+---
+title: 'Timbres Marcantes em Hits'
+description: 'Curadoria de sons icônicos usados em músicas brasileiras e americanas'
+---
+
+## Timbres que marcaram o Brega e a Música Brasileira
+
+- **Acordeon Digital** – Presente em diversos sucessos do forró eletrônico e do brega. Modelos de teclados populares (Yamaha PSR, Roland E‑series) ofereciam timbres de sanfona que dominaram os anos 2000.
+- **Brass Sintetizado** – As famosas "metaleiras" de teclados como o Korg M1 e o Roland JV‑1080 aparecem em muitas bandas de brega e axé, dando força às linhas de metais.
+- **Piano Elétrico FM** – O timbre de "DX7 E.Piano" tornou-se onipresente em baladas românticas e hits pop nacionais dos anos 80 e 90.
+- **Strings e Pads** – Camadas de cordas sintetizadas, especialmente do Roland D‑50, ajudaram a criar atmosferas dramáticas em inúmeras canções populares.
+- **Guitarra Clean/Chorus** – Muito usada em lambada e brega romântico, essa sonoridade suave aparece em gravações célebres de artistas brasileiros.
+
+## Timbres que brilharam em hits americanos e internacionais
+
+- **Piano Korg M1** – O patch "M1 Piano" esteve presente em incontáveis músicas de dance e pop no final dos anos 80 e início dos 90.
+- **Roland D‑50 "Fantasia"** – Clássico timbre usado em trilhas e canções new age, marcou a sonoridade de discos internacionais da época.
+- **Bass de Moog** – Linhas de baixo encorpadas criadas em sintetizadores analógicos (Minimoog, Moog Source) são destaque em hits do funk e do pop americano.
+- **TR‑808 e TR‑909** – As baterias eletrônicas da Roland moldaram estilos como hip hop, house e techno, aparecendo em inúmeros sucessos mundiais.
+- **Synth Brass "Digital Native Dance"** – Outro clássico do D‑50, muito usado em músicas pop e trilhas de filmes no fim dos anos 80.
+
+Esta lista traz apenas alguns exemplos de timbres que se tornaram referência e continuam inspirando produções musicais em todo o mundo.


### PR DESCRIPTION
## Summary
- add guide for notable timbres in hit songs
- include new page in Mintlify navigation

## Testing
- `python -m py_compile $(find raspi-workstation -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685fab6ec014832dafebcd3f57f40883